### PR TITLE
webpack配置bug修复

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "src/app.js",
   "scripts": {
-    "build": "export NODE_ENV=production && webpack",
-    "start": "export NODE_ENV=development && webpack-dev-server",
-    "build-win": "SET NODE_ENV=production && webpack",
-    "start-win": "SET NODE_ENV=development && webpack-dev-server",
+    "build": "export NODE_ENV=production&&webpack",
+    "start": "export NODE_ENV=development&&webpack-dev-server",
+    "build-win": "SET NODE_ENV=production&&webpack",
+    "start-win": "SET NODE_ENV=development&&webpack-dev-server",
     "lint": "eslint --ext .js src"
   },
   "author": "shiyanlin",


### PR DESCRIPTION
在window环境下package.json中的scripts配置，空格导致webpack配置中判断是否运行生产命令（build）错误。